### PR TITLE
test(api): Add test suite for 'v1/launches' route

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "NASA Mission Control API",
   "main": "src/server.js",
   "scripts": {
-    "test": "jest --detectOpenHandles",
+    "test": "jest",
     "test-watch": "test --watch",
     "watch": "nodemon src/server.js",
     "start": "node src/server.js",

--- a/server/tests/integration/launches.test.js
+++ b/server/tests/integration/launches.test.js
@@ -1,0 +1,87 @@
+const request = require("supertest");
+
+const app = require("../../src/app");
+
+const { connectDB, disconnectDB } = require("../../src/utils/db");
+
+const { loadPlanetsData } = require("../../src/models/planet.model");
+
+describe("/v1/launches", () => {
+  beforeAll(async () => {
+    await connectDB();
+    await loadPlanetsData();
+  });
+
+  afterAll(async () => {
+    await disconnectDB();
+  });
+
+  describe("GET /launches", () => {
+    test("It should respond with 200 success", async () => {
+      const response = await request(app)
+        .get("/v1/launches")
+        .expect("Content-Type", /json/)
+        .expect(200);
+    });
+  });
+
+  describe("POST /launches", () => {
+    const completeLaunchData = {
+      mission: "USS Enterprise",
+      rocket: "NCC 1701-D",
+      target: "Kepler-62 f",
+      launchDate: "January 4, 2028",
+    };
+
+    const launchDataWithoutDate = {
+      mission: "USS Enterprise",
+      rocket: "NCC 1701-D",
+      target: "Kepler-62 f",
+    };
+
+    const launchDataWithInvalidDate = {
+      mission: "USS Enterprise",
+      rocket: "NCC 1701-D",
+      target: "Kepler-62 f",
+      launchDate: "fakeLaunchData",
+    };
+
+    test("It should respond with 201 created", async () => {
+      const response = await request(app)
+        .post("/v1/launches")
+        .send(completeLaunchData)
+        .expect("Content-Type", /json/)
+        .expect(201);
+
+      const requestDate = new Date(completeLaunchData.launchDate).valueOf();
+      const responseDate = new Date(response.body.launchDate).valueOf();
+      expect(responseDate).toBe(requestDate);
+
+      expect(response.body).toMatchObject(launchDataWithoutDate);
+    });
+
+    test("It should catch missing required properties", async () => {
+      const response = await request(app)
+        .post("/v1/launches")
+        .send(launchDataWithoutDate)
+        .expect("Content-Type", /json/)
+        .expect(400);
+
+      expect(response.body).toStrictEqual({
+        error: "Missing required launch property",
+      });
+    });
+
+    test("It should catch invalid dates", async () => {
+      const response = await request(app)
+        .post("/v1/launches")
+        .send(launchDataWithInvalidDate)
+        .expect("Content-Type", /json/)
+        .expect(400);
+
+      expect(response.body).toStrictEqual({
+        error: "Invalid launch date",
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit sets up a test suite for the _**'v1/launches'**_ route. 

- [x] GET /launches
	- [x] Respond with 200 success
- [x] POST /launches
	- [x] Respond with 201 created
	- [x] Catch missing required properties
	- [x] Catch invalid dates

The test suite will be updated with more tests to cover more edge cases in the future commits.